### PR TITLE
chore: Use secret for Google Maps API key in contact page

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -56,6 +56,8 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+      env:
+        GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
     runs-on: ubuntu-22.04 
     needs: build
     steps:

--- a/_layouts/contact.html
+++ b/_layouts/contact.html
@@ -46,7 +46,7 @@ layout: default
   }
 </script>
 
-<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAylpUhutIzp68cX8SZbSLqX_AxKDriNPM&callback=myMap"></script>
+<script src="https://maps.googleapis.com/maps/api/js?key=${{ secrets.GOOGLE_MAPS_API_KEY }}&callback=myMap"></script>
 
 <script>
   var form = document.getElementById("contact-form");


### PR DESCRIPTION
Replaces the hardcoded Google Maps API key in contact.html with a reference to the GitHub secret. Updates the workflow to pass GOOGLE_MAPS_API_KEY as an environment variable for improved security.