### PR TITLE
chore: Set GOOGLE_MAPS_API_KEY in build environment

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -47,6 +47,7 @@ jobs:
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
+          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v3
@@ -56,8 +57,6 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-      env:
-        GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
     runs-on: ubuntu-22.04 
     needs: build
     steps:


### PR DESCRIPTION
Moves the GOOGLE_MAPS_API_KEY secret to the build step environment instead of the deployment environment in the Jekyll GitHub Actions workflow. Ensures the API key is available during site build.