### PR TITLE
chore: Add Google Maps API key to deploy environment

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -63,3 +63,5 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        env:
+          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}


### PR DESCRIPTION
Sets the GOOGLE_MAPS_API_KEY environment variable during the GitHub Pages deployment step using a secret. This enables access to the Google Maps API in the deployed site.