### PR TITLE
Update Google Maps API key usage in build and contact page

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -44,10 +44,7 @@ jobs:
         uses: actions/configure-pages@v5
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
-        run: |
-          echo "secret-variable: $GOOGLE_MAPS_API_KEY" >> _config.yml
-          bundle exec jekyll build --baseurl "${{ site.pages.outputs.base_path }}"
-          sed -i '$d' _config.yml  # removes the appended line after build
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}

--- a/_layouts/contact.html
+++ b/_layouts/contact.html
@@ -46,7 +46,7 @@ layout: default
   }
 </script>
 
-<script src="https://maps.googleapis.com/maps/api/js?key={{site.GOOGLE_MAPS_API_KEY}}&callback=myMap"></script>
+<script src="https://maps.googleapis.com/maps/api/js?key=${{ secrets.GOOGLE_MAPS_API_KEY }}&callback=myMap"></script>
 
 <script>
   var form = document.getElementById("contact-form");


### PR DESCRIPTION
Simplifies Jekyll build workflow by removing dynamic config modification for the Google Maps API key and updates contact page to use GitHub Actions secrets for the API key directly in the script source.