### PR TITLE
Inject Google Maps API key into Jekyll build

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -44,7 +44,10 @@ jobs:
         uses: actions/configure-pages@v5
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
-        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        run: |
+          echo "secret-variable: $GOOGLE_MAPS_API_KEY" >> _config.yml
+          bundle exec jekyll build --baseurl "${{ site.pages.outputs.base_path }}"
+          sed -i '$d' _config.yml  # removes the appended line after build
         env:
           JEKYLL_ENV: production
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}

--- a/_layouts/contact.html
+++ b/_layouts/contact.html
@@ -46,7 +46,7 @@ layout: default
   }
 </script>
 
-<script src="https://maps.googleapis.com/maps/api/js?key=${{ secrets.GOOGLE_MAPS_API_KEY }}&callback=myMap"></script>
+<script src="https://maps.googleapis.com/maps/api/js?key={{ site.GOOGLE_MAPS_API_KEY }}&callback=myMap"></script>
 
 <script>
   var form = document.getElementById("contact-form");


### PR DESCRIPTION
The workflow now appends the Google Maps API key to _config.yml before building and removes it after. The contact page script now references the API key from site config instead of GitHub secrets.