### PR TITLE
Fix baseurl reference in Jekyll build workflow

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -46,8 +46,8 @@ jobs:
         # Outputs to the './_site' directory by default
         run: |
           echo "secret-variable: $GOOGLE_MAPS_API_KEY" >> _config.yml
-          bundle exec jekyll build --baseurl "${{ site.pages.outputs.base_path }}"
-          sed -i '$d' _config.yml  # removes the appended line after build
+          bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+          sed -i '$d' _config.yml
         env:
           JEKYLL_ENV: production
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}


### PR DESCRIPTION
Updated the Jekyll build step to use 'steps.pages.outputs.base_path' instead of 'site.pages.outputs.base_path' for the baseurl parameter in the GitHub Actions workflow.