### PR TITLE
Update Jekyll build to use correct API key variable

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: |
-          echo "secret-variable: $GOOGLE_MAPS_API_KEY" >> _config.yml
+          echo "GOOGLE_MAPS_API_KEY: $GOOGLE_MAPS_API_KEY" >> _config.yml
           bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
           sed -i '$d' _config.yml
         env:


### PR DESCRIPTION
Changed the injected config variable from 'secret-variable' to 'GOOGLE_MAPS_API_KEY' in the Jekyll build workflow to ensure the API key is referenced correctly during site generation.