### PR TITLE
Remove sed command from Jekyll build workflow

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -47,7 +47,6 @@ jobs:
         run: |
           echo "GOOGLE_MAPS_API_KEY: $GOOGLE_MAPS_API_KEY" >> _config.yml
           bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
-          sed -i '$d' _config.yml
         env:
           JEKYLL_ENV: production
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}


### PR DESCRIPTION
Eliminates the line that deleted the last line of _config.yml after the Jekyll build step, simplifying the workflow and preventing unintended config modifications.