### PR TITLE
Use environment variable for Google Maps API key

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: |
-          echo "GOOGLE_MAPS_API_KEY: THIS_IS_A_TEST_API_KEY" >> _config.yml
+          echo "GOOGLE_MAPS_API_KEY: ${{ env.GOOGLE_MAPS_API_KEY }}" >> _config.yml
           bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production


### PR DESCRIPTION
Replaces the hardcoded Google Maps API key in the Jekyll build step with the value from the GOOGLE_MAPS_API_KEY environment variable for improved security and flexibility.