### PR TITLE
Update Jekyll workflow environment variable usage

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: |
-          echo "GOOGLE_MAPS_API_KEY: ${{ env.GOOGLE_MAPS_API_KEY }}" >> _config.yml
+          echo "GOOGLE_MAPS_API_KEY: ${GOOGLE_MAPS_API_KEY}" >> _config.yml
           bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
@@ -65,5 +65,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-        env:
-          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}


### PR DESCRIPTION
Replaces GitHub Actions expression syntax with direct environment variable reference for GOOGLE_MAPS_API_KEY in the build step. Removes redundant environment variable declaration from the deploy step.