### PR TITLE
Specify bash shell for Jekyll build step

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -50,6 +50,7 @@ jobs:
         env:
           JEKYLL_ENV: production
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+        shell: bash
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Adds 'shell: bash' to the Jekyll build step in the GitHub Actions workflow to ensure consistent shell execution.