### PR TITLE
Move GOOGLE_MAPS_API_KEY to environment export

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -42,6 +42,8 @@ jobs:
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
+      - name: Export secret for next steps
+        run: echo "GOOGLE_MAPS_API_KEY=${{ secrets.GOOGLE_MAPS_API_KEY }}" >> $GITHUB_ENV
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: |
@@ -49,7 +51,6 @@ jobs:
           bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
-          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
         shell: bash
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default


### PR DESCRIPTION
Exports GOOGLE_MAPS_API_KEY to the GitHub Actions environment using $GITHUB_ENV instead of passing it directly in the Jekyll build step. This improves secret management and makes the key available to subsequent steps.