### PR TITLE
Inject Google Maps API key directly into Jekyll config

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -42,13 +42,14 @@ jobs:
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
-      - name: Export secret for next steps
-        run: echo "GOOGLE_MAPS_API_KEY=${{ secrets.GOOGLE_MAPS_API_KEY }}" >> $GITHUB_ENV
+      - name: Inject Google Maps API key to config
+        run: |
+          echo "GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}" >> ./_config.yml
+          cat ./_config.yml
+        shell: bash
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
-        run: |
-          echo "GOOGLE_MAPS_API_KEY: ${GOOGLE_MAPS_API_KEY}" >> _config.yml
-          bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
         shell: bash


### PR DESCRIPTION
Moves the Google Maps API key injection from the environment to directly appending it to _config.yml in the workflow. This streamlines the build process and ensures the key is present in the Jekyll configuration before building.