### PR TITLE
Move Google Maps API key injection to deploy step

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -42,17 +42,11 @@ jobs:
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
-      - name: Inject Google Maps API key to config
-        run: |
-          echo "GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}" >> ./_config.yml
-          cat ./_config.yml
-        shell: bash
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
-        shell: bash
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v3
@@ -61,10 +55,18 @@ jobs:
   deploy:
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-22.04 
+    runs-on: ubuntu-22.04
     needs: build
     steps:
-      - name: Deploy to GitHub Pages
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: github-pages
+          path: ./_site
+      - name: Inject secret before deploy
+        run: sed -i "s/GOOGLE_MAPS_API_KEY/${{ secrets.GOOGLE_MAPS_API_KEY }}/" ./_site/contact.html
+      - name: Deploy
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
The workflow now injects the Google Maps API key into the built site during the deploy job instead of modifying _config.yml during build. This ensures the secret is only added to the final output and not present in the source configuration.