### PR TITLE
Update secret injection to index.html

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -66,7 +66,7 @@ jobs:
           name: github-pages
           path: ./_site
       - name: Inject secret before deploy
-        run: sed -i "s/GOOGLE_MAPS_API_KEY/${{ secrets.GOOGLE_MAPS_API_KEY }}/" ./_site/contact.html
+        run: sed -i "s/GOOGLE_MAPS_API_KEY/${{ secrets.GOOGLE_MAPS_API_KEY }}/" ./_site/index.html
       - name: Deploy
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
The workflow now injects the GOOGLE_MAPS_API_KEY secret into ./_site/index.html instead of ./_site/contact.html before deployment.