### PR TITLE
Inject Google Maps API key into all HTML files

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -65,8 +65,11 @@ jobs:
         with:
           name: github-pages
           path: ./_site
-      - name: Inject secret before deploy
-        run: sed -i "s/GOOGLE_MAPS_API_KEY/${{ secrets.GOOGLE_MAPS_API_KEY }}/" ./_site/index.html
+      - name: Inject Google Maps API key
+        run: |
+          find ./_site -type f -name "*.html" -print0 | \
+            xargs -0 sed -i "s#GOOGLE_MAPS_API_KEY#${{ secrets.GOOGLE_MAPS_API_KEY }}#g"
       - name: Deploy
         id: deployment
         uses: actions/deploy-pages@v4
+        


### PR DESCRIPTION
Updated the workflow to replace GOOGLE_MAPS_API_KEY in all HTML files within the _site directory before deployment, instead of only index.html. This ensures the API key is injected wherever needed across the site.